### PR TITLE
Add Windows support, make things cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 Simple python program to download all of the podcasts on a specified Libsyn page.  Format for supplying a webpage to download from should look like this `http://billburr.libsyn.com/webpage/page/1/size/1000` where 1 is how many pages and 1000 is how many items appear per page.  Using this format will put all the podcasts on one long page which the program will then parse.  
 
-### Setup
+## Setup
 
-`./install-dependencies.sh`
+### Windows
 
-### Running.
+1. Get the latest Python 2.7 release (currently 2.7.11) from https://www.python.org/downloads/
+2. Run the installer, making sure to select "add python.exe to Path" in the installation options
+3. Open an administrator command prompt in this folder, and run `python installer.py`
 
-`python downloader.py`
+### Linux
 
-### If You Encounter Troubles.
+Run `./linux-dependencies.sh`
 
-If you have any issues with downloads stopping, try using [torsocks](https://github.com/dgoulet/torsocks).
+## Running
 
-`torsocks python downloader.py`
+Run `python downloader.py`

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-#
-#   Author: Darrin Schmitz
-#   Date: 3/19/2016
-
-sudo apt-get install python2.7 python-bs4 tor
-
-sudo service tor start

--- a/linux-dependencies.sh
+++ b/linux-dependencies.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+#   Author: Darrin Schmitz, Ryan Rowe
+#   Date: 3/21/2016
+#
+#   Uses code from http://stackoverflow.com/a/19520888/2508324
+
+YUM_CMD=$(which yum)
+APT_GET_CMD=$(which apt-get)
+
+if [[ ! -z $YUM_CMD ]]; then
+    sudo yum install python2.7
+ elif [[ ! -z $APT_GET_CMD ]]; then
+    sudo apt-get python2.7
+else
+	echo "error can't install python2.7 and python-bs4"
+	exit 1;
+fi
+
+sudo python install.py


### PR DESCRIPTION
Windows support: added instructions in README.md on how to download and install Python

Linux: added support for `yum`-based distros

General: moved installation of `beautifulsoup4` to a script that will work without needing `pip` to be on the system path (primarily for Windows)
